### PR TITLE
Add escape key to quit program, closes #5

### DIFF
--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -143,6 +143,10 @@ pub fn grab_escape_key(conn: &xcb::Connection, root: u32) {
     );
 }
 
+pub fn ungrab_escape_key(conn: &xcb::Connection, root: u32) {
+    xcb::ungrab_key(&conn, 9, root, xcb::NONE as u16);
+}
+
 fn viewable(conn: &xcb::Connection, win: xcb::Window) -> bool {
     let attrs = xcb::get_window_attributes(conn, win).get_reply().unwrap();
     (attrs.map_state() & xcb::MAP_STATE_VIEWABLE as u8) != 0

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -7,6 +7,19 @@ use xcb::shape;
 pub const CURSOR_GRAB_TRIES: i32 = 5;
 const ESC_KEYCODE: u8 = 9;
 
+const KEY_GRAB_MASKS: [u32; 10] = [
+    xcb::NONE,
+    xcb::MOD_MASK_SHIFT,
+    xcb::MOD_MASK_CONTROL,
+    xcb::MOD_MASK_LOCK,
+    xcb::MOD_MASK_1,
+    xcb::MOD_MASK_2,
+    xcb::MOD_MASK_3,
+    xcb::MOD_MASK_4,
+    xcb::MOD_MASK_5,
+    xcb::MOD_MASK_ANY,
+];
+
 #[derive(Clone, Copy)]
 pub struct HacksawResult {
     pub window: u32,
@@ -133,19 +146,23 @@ pub fn grab_pointer_set_cursor(conn: &xcb::Connection, root: u32) -> bool {
 }
 
 pub fn grab_escape_key(conn: &xcb::Connection, root: u32) {
-    xcb::grab_key(
-        &conn,
-        true,
-        root,
-        xcb::NONE as u16,
-        ESC_KEYCODE,
-        xcb::GRAB_MODE_ASYNC as u8,
-        xcb::GRAB_MODE_ASYNC as u8,
-    );
+    for &mask in KEY_GRAB_MASKS.iter() {
+        xcb::grab_key(
+            &conn,
+            true,
+            root,
+            mask as u16,
+            ESC_KEYCODE,
+            xcb::GRAB_MODE_ASYNC as u8,
+            xcb::GRAB_MODE_ASYNC as u8,
+        );
+    }
 }
 
 pub fn ungrab_escape_key(conn: &xcb::Connection, root: u32) {
-    xcb::ungrab_key(&conn, ESC_KEYCODE, root, xcb::NONE as u16);
+    for &mask in KEY_GRAB_MASKS.iter() {
+        xcb::ungrab_key(&conn, ESC_KEYCODE, root, mask as u16);
+    }
 }
 
 fn viewable(conn: &xcb::Connection, win: xcb::Window) -> bool {

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -131,6 +131,18 @@ pub fn grab_pointer_set_cursor(conn: &xcb::Connection, root: u32) -> bool {
     false
 }
 
+pub fn grab_escape_key(conn: &xcb::Connection, root: u32) {
+    xcb::grab_key(
+        &conn,
+        true,
+        root,
+        xcb::MOD_MASK_ANY as u16,
+        9, // ESCAPE, would be nice if wasn't a magic number
+        xcb::GRAB_MODE_ASYNC as u8,
+        xcb::GRAB_MODE_ASYNC as u8,
+    );
+}
+
 fn viewable(conn: &xcb::Connection, win: xcb::Window) -> bool {
     let attrs = xcb::get_window_attributes(conn, win).get_reply().unwrap();
     (attrs.map_state() & xcb::MAP_STATE_VIEWABLE as u8) != 0

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -5,6 +5,7 @@ use self::parse_format::FormatToken;
 use xcb::shape;
 
 pub const CURSOR_GRAB_TRIES: i32 = 5;
+const ESC_KEYCODE: u8 = 9;
 
 #[derive(Clone, Copy)]
 pub struct HacksawResult {
@@ -137,14 +138,14 @@ pub fn grab_escape_key(conn: &xcb::Connection, root: u32) {
         true,
         root,
         xcb::MOD_MASK_ANY as u16,
-        9, // ESCAPE, would be nice if wasn't a magic number
+        ESC_KEYCODE,
         xcb::GRAB_MODE_ASYNC as u8,
         xcb::GRAB_MODE_ASYNC as u8,
     );
 }
 
 pub fn ungrab_escape_key(conn: &xcb::Connection, root: u32) {
-    xcb::ungrab_key(&conn, 9, root, xcb::NONE as u16);
+    xcb::ungrab_key(&conn, ESC_KEYCODE, root, xcb::NONE as u16);
 }
 
 fn viewable(conn: &xcb::Connection, win: xcb::Window) -> bool {

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -137,7 +137,7 @@ pub fn grab_escape_key(conn: &xcb::Connection, root: u32) {
         &conn,
         true,
         root,
-        xcb::MOD_MASK_ANY as u16,
+        xcb::NONE as u16,
         ESC_KEYCODE,
         xcb::GRAB_MODE_ASYNC as u8,
         xcb::GRAB_MODE_ASYNC as u8,

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,8 @@ mod lib;
 
 use lib::parse_args::Opt;
 use lib::{
-    get_window_at_point, get_window_geom, grab_pointer_set_cursor, set_shape,
-    set_title, HacksawResult, CURSOR_GRAB_TRIES, grab_escape_key,
+    get_window_at_point, get_window_geom, grab_escape_key, grab_pointer_set_cursor, set_shape,
+    set_title, ungrab_escape_key, HacksawResult, CURSOR_GRAB_TRIES,
 };
 use structopt::StructOpt;
 
@@ -204,7 +204,7 @@ fn main() -> Result<(), String> {
     }
 
     xcb::ungrab_pointer(&conn, xcb::CURRENT_TIME);
-    xcb::ungrab_key(&conn, 9, window, xcb::MOD_MASK_ANY as u16);
+    ungrab_escape_key(&conn, root);
     xcb::unmap_window(&conn, window);
     xcb::destroy_window(&conn, window);
     conn.flush();

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,10 @@ fn main() -> Result<(), String> {
 
     // TODO fix pointer-grab? bug where hacksaw hangs if mouse held down before run
     if !grab_pointer_set_cursor(&conn, root) {
-        return Err(format!("Failed to grab cursor after {} tries, giving up", CURSOR_GRAB_TRIES));
+        return Err(format!(
+            "Failed to grab cursor after {} tries, giving up",
+            CURSOR_GRAB_TRIES
+        ));
     }
 
     grab_escape_key(&conn, root);


### PR DESCRIPTION
Please test this, it _should_ let everything else passthrough except for ESC. Also should be pretty easy to add another key to quit key if we want.