### PR TITLE
Find escape by keysym not keycode

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ cargo install --git https://github.com/neXromancers/hacksaw
 ### Stability
 - Main functionality is all there and pretty solid
 - You may experience bugs when invoking hacksaw while a popup is open
-- Pressing escape to exit selection is not yet implemented
 
 ### Usage
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,8 @@ mod lib;
 
 use lib::parse_args::Opt;
 use lib::{
-    get_window_at_point, get_window_geom, grab_escape_key, grab_pointer_set_cursor, set_shape,
-    set_title, ungrab_escape_key, HacksawResult, CURSOR_GRAB_TRIES,
+    find_escape_keycode, get_window_at_point, get_window_geom, grab_key, grab_pointer_set_cursor,
+    set_shape, set_title, ungrab_key, HacksawResult, CURSOR_GRAB_TRIES,
 };
 use structopt::StructOpt;
 
@@ -52,7 +52,8 @@ fn main() -> Result<(), String> {
         ));
     }
 
-    grab_escape_key(&conn, root);
+    let escape_keycode = find_escape_keycode(&conn);
+    grab_key(&conn, root, escape_keycode);
 
     let screen_rect =
         xcb::Rectangle::new(0, 0, screen.width_in_pixels(), screen.height_in_pixels());
@@ -207,7 +208,7 @@ fn main() -> Result<(), String> {
     }
 
     xcb::ungrab_pointer(&conn, xcb::CURRENT_TIME);
-    ungrab_escape_key(&conn, root);
+    ungrab_key(&conn, root, escape_keycode);
     xcb::unmap_window(&conn, window);
     xcb::destroy_window(&conn, window);
     conn.flush();


### PR DESCRIPTION
Keycode are hard representation of what key was pressed but it may not
be escape keysym.