### PR TITLE
Use x11rb instead of rust-xcb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,11 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "cc"
+version = "1.0.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -43,11 +48,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "hacksaw"
 version = "1.0.4"
 dependencies = [
  "structopt 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "xcb 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "x11rb 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -77,11 +91,15 @@ version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "log"
-version = "0.4.8"
+name = "nix"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -205,6 +223,11 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "winapi"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -224,25 +247,27 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "xcb"
-version = "0.9.0"
+name = "x11rb"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gethostname 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [metadata]
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+"checksum cc 1.0.54 (registry+https://github.com/rust-lang/crates.io-index)" = "7bbb73db36c1246e9034e307d0fba23f9a2e251faa47ade70c1bd252220c8311"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
+"checksum gethostname 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e692e296bfac1d2533ef168d0b60ff5897b8b70a4009276834014dd8924cc028"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hermit-abi 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "725cf19794cf90aa94e65050cb4191ff5d8fa87a498383774c47b332e3af952e"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)" = "dea0c0405123bba743ee3f91f49b1c7cfb684eef0da0a50110f758ccf24cdff0"
-"checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
+"checksum nix 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
 "checksum proc-macro-error 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "18f33027081eba0a6d8aba6d1b1c3a3be58cbb12106341c2d5759fcd9b5277e7"
 "checksum proc-macro-error-attr 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "8a5b4b77fdb63c1eca72173d68d24501c54ab1269409f6b672c85deb18af69de"
 "checksum proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)" = "df246d292ff63439fea9bc8c0a270bed0e390d5ebd4db4ba15aba81111b5abe3"
@@ -258,7 +283,8 @@ dependencies = [
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
+"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-"checksum xcb 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "62056f63138b39116f82a540c983cc11f1c90cd70b3d492a70c25eaa50bd22a6"
+"checksum x11rb 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4f977c7d3836241e638b4696e9dbda53d09920514a2f8caffe479c3548428f4a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 [dependencies]
 structopt = "0.3"
 
-[dependencies.xcb]
-version = "0.9"
+[dependencies.x11rb]
+version = "0.5"
+default-features = false
 features = ["xkb", "shape"]

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -40,8 +40,8 @@ impl HacksawResult {
         HacksawResult {
             window: self.window,
             rect: xproto::Rectangle {
-                x: parent.x() - self.x(),
-                y: parent.y() - self.y(),
+                x: parent.x() + self.x(),
+                y: parent.y() + self.y(),
                 width: self.width(),
                 height: self.height(),
             },
@@ -99,7 +99,7 @@ pub fn set_title<C: Connection>(conn: &C, window: xproto::Window, title: &str) {
         window,
         xproto::AtomEnum::WM_NAME,
         xproto::AtomEnum::STRING,
-        xproto::AtomEnum::STRING as u8,
+        8,
         title.len() as u32,
         title.as_bytes(),
     ).unwrap().check().unwrap();

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -2,9 +2,9 @@ pub mod parse_args;
 pub mod parse_format;
 
 use self::parse_format::FormatToken;
+use x11rb::connection::Connection;
 use x11rb::protocol::shape;
 use x11rb::protocol::xproto;
-use x11rb::connection::Connection;
 
 pub const CURSOR_GRAB_TRIES: i32 = 5;
 const ESC_KEYSYM: u32 = 0xff1b;
@@ -89,7 +89,10 @@ pub fn set_shape<C: Connection>(conn: &C, window: xproto::Window, rects: &[xprot
         0,
         0,
         &rects,
-    ).unwrap().check().unwrap();
+    )
+    .unwrap()
+    .check()
+    .unwrap();
 }
 
 pub fn set_title<C: Connection>(conn: &C, window: xproto::Window, title: &str) {
@@ -102,17 +105,26 @@ pub fn set_title<C: Connection>(conn: &C, window: xproto::Window, title: &str) {
         8,
         title.len() as u32,
         title.as_bytes(),
-    ).unwrap().check().unwrap();
+    )
+    .unwrap()
+    .check()
+    .unwrap();
 }
 
 pub fn grab_pointer_set_cursor<C: Connection>(conn: &C, root: u32) -> bool {
     let font = conn.generate_id().unwrap();
-    xproto::open_font(conn, font, b"cursor").unwrap().check().unwrap();
+    xproto::open_font(conn, font, b"cursor")
+        .unwrap()
+        .check()
+        .unwrap();
 
     // TODO: create cursor with a Pixmap
     // https://stackoverflow.com/questions/40578969/how-to-create-a-cursor-in-x11-from-raw-data-c
     let cursor = conn.generate_id().unwrap();
-    xproto::create_glyph_cursor(conn, cursor, font, font, 0, 30, 0, 0, 0, 0, 0, 0).unwrap().check().unwrap();
+    xproto::create_glyph_cursor(conn, cursor, font, font, 0, 30, 0, 0, 0, 0, 0, 0)
+        .unwrap()
+        .check()
+        .unwrap();
 
     for i in 0..CURSOR_GRAB_TRIES {
         let reply = xproto::grab_pointer(
@@ -128,7 +140,10 @@ pub fn grab_pointer_set_cursor<C: Connection>(conn: &C, root: u32) -> bool {
             x11rb::NONE,
             cursor,
             x11rb::CURRENT_TIME,
-        ).unwrap().reply().unwrap();
+        )
+        .unwrap()
+        .reply()
+        .unwrap();
 
         if reply.status == xproto::GrabStatus::Success {
             return true;
@@ -147,7 +162,8 @@ pub fn find_escape_keycode<C: Connection>(conn: &C) -> xproto::Keycode {
         conn,
         setup.min_keycode,
         setup.max_keycode - setup.min_keycode + 1,
-    ).unwrap();
+    )
+    .unwrap();
     let reply = cookie.reply().expect("failed to get keyboard mapping");
 
     let escape_index = reply
@@ -168,23 +184,35 @@ pub fn grab_key<C: Connection>(conn: &C, root: u32, keycode: u8) {
             keycode,
             xproto::GrabMode::Async,
             xproto::GrabMode::Async,
-        ).unwrap().check().unwrap();
+        )
+        .unwrap()
+        .check()
+        .unwrap();
     }
 }
 
 pub fn ungrab_key<C: Connection>(conn: &C, root: u32, keycode: u8) {
     for mask in 0..=KEY_GRAB_MASK_MAX {
-        xproto::ungrab_key(conn, keycode, root, mask).unwrap().check().unwrap();
+        xproto::ungrab_key(conn, keycode, root, mask)
+            .unwrap()
+            .check()
+            .unwrap();
     }
 }
 
 fn viewable<C: Connection>(conn: &C, win: xproto::Window) -> bool {
-    let attrs = xproto::get_window_attributes(conn, win).unwrap().reply().unwrap();
+    let attrs = xproto::get_window_attributes(conn, win)
+        .unwrap()
+        .reply()
+        .unwrap();
     attrs.map_state == xproto::MapState::Viewable
 }
 
 pub fn input_output<C: Connection>(conn: &C, win: xproto::Window) -> bool {
-    let attrs = xproto::get_window_attributes(conn, win).unwrap().reply().unwrap();
+    let attrs = xproto::get_window_attributes(conn, win)
+        .unwrap()
+        .reply()
+        .unwrap();
     attrs.class == xproto::WindowClass::InputOutput
 }
 
@@ -230,7 +258,10 @@ pub fn get_window_at_point<C: Connection>(
 
     let mut window = children[children.len() - 1];
     for _ in 0..remove_decorations {
-        let tree = xproto::query_tree(conn, window.window).unwrap().reply().unwrap();
+        let tree = xproto::query_tree(conn, window.window)
+            .unwrap()
+            .reply()
+            .unwrap();
         if tree.children.is_empty() {
             break;
         }

--- a/src/lib/parse_format.rs
+++ b/src/lib/parse_format.rs
@@ -29,7 +29,7 @@ pub(crate) fn parse_format_string(input: &str) -> Result<Format, String> {
                 Some((b'%', rest)) => (FormatToken::Literal("%".to_owned()), rest),
                 Some((c, _)) => break Err(format!("Unknown format '%{}'", *c as char)),
                 None => break Err("Incorrectly terminated '%'".to_owned()),
-            }
+            },
             Some((_, _)) => {
                 let next_perc = input.iter().position(|&c| c == b'%');
                 let (literal, rest) = input.split_at(next_perc.unwrap_or_else(|| input.len()));

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,3 @@
-extern crate structopt;
-extern crate x11rb;
-
 mod lib;
 
 use lib::parse_args::Opt;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 extern crate structopt;
-extern crate xcb;
+extern crate x11rb;
+
 mod lib;
 
 use lib::parse_args::Opt;
@@ -8,6 +9,8 @@ use lib::{
     set_shape, set_title, ungrab_key, HacksawResult, CURSOR_GRAB_TRIES,
 };
 use structopt::StructOpt;
+use x11rb::protocol::{xproto, Event};
+use x11rb::connection::Connection;
 
 fn min_max(a: i16, b: i16) -> (i16, i16) {
     if a < b {
@@ -17,15 +20,21 @@ fn min_max(a: i16, b: i16) -> (i16, i16) {
     }
 }
 
-fn build_guides(screen: xcb::Rectangle, pt: xcb::Point, width: u16) -> [xcb::Rectangle; 2] {
+fn build_guides(screen: xproto::Rectangle, pt: xproto::Point, width: u16) -> [xproto::Rectangle; 2] {
     [
-        xcb::Rectangle::new(
-            pt.x() - width as i16 / 2,
-            screen.x(),
-            width,
-            screen.height(),
-        ),
-        xcb::Rectangle::new(screen.y(), pt.y() - width as i16 / 2, screen.width(), width),
+        xproto::Rectangle {
+            x: pt.x - width as i16 / 2,
+            y: screen.x,
+            width: width,
+            height: screen.height,
+        },
+
+        xproto::Rectangle {
+            x: screen.y,
+            y: pt.y - width as i16 / 2,
+            width: screen.width,
+            height: width,
+        }
     ]
 }
 
@@ -37,12 +46,12 @@ fn main() -> Result<(), String> {
     let line_colour = opt.line_colour;
     let format = opt.format;
 
-    let (conn, screen_num) = xcb::Connection::connect(None).unwrap();
-    let setup = conn.get_setup();
-    let screen = setup.roots().nth(screen_num as usize).unwrap();
-    let root = screen.root();
+    let (conn, screen_num) = x11rb::rust_connection::RustConnection::connect(None).unwrap();
+    let setup = conn.setup();
+    let screen = &setup.roots[screen_num];
+    let root = screen.root;
 
-    let window = conn.generate_id();
+    let window = conn.generate_id().unwrap();
 
     // TODO fix pointer-grab? bug where hacksaw hangs if mouse held down before run
     if !grab_pointer_set_cursor(&conn, root) {
@@ -55,61 +64,76 @@ fn main() -> Result<(), String> {
     let escape_keycode = find_escape_keycode(&conn);
     grab_key(&conn, root, escape_keycode);
 
-    let screen_rect =
-        xcb::Rectangle::new(0, 0, screen.width_in_pixels(), screen.height_in_pixels());
+    let screen_rect = xproto::Rectangle {
+        x: 0,
+        y: 0,
+        width: screen.width_in_pixels,
+        height: screen.height_in_pixels
+    };
 
     // TODO event handling for expose/keypress
-    let values = [
-        // ?RGB. First 4 bytes appear to do nothing
-        (xcb::CW_BACK_PIXEL, line_colour),
-        (
-            xcb::CW_EVENT_MASK,
-            xcb::EVENT_MASK_EXPOSURE
-            | xcb::EVENT_MASK_KEY_PRESS // we'll need this later
-            | xcb::EVENT_MASK_STRUCTURE_NOTIFY
-            | xcb::EVENT_MASK_SUBSTRUCTURE_NOTIFY,
-        ),
-        (xcb::CW_OVERRIDE_REDIRECT, 1u32), // Don't be window managed
-    ];
+    let value_list = xproto::CreateWindowAux::new()
+        .background_pixel(line_colour)
+        .event_mask(xproto::EventMask::Exposure
+                        | xproto::EventMask::KeyPress
+                        | xproto::EventMask::StructureNotify
+                        | xproto::EventMask::SubstructureNotify)
+        .override_redirect(1);
 
-    xcb::create_window(
+    xproto::create_window(
         &conn,
-        xcb::COPY_FROM_PARENT as u8, // usually 32?
+        x11rb::COPY_DEPTH_FROM_PARENT,
         window,
         root,
-        screen_rect.x(),
-        screen_rect.y(),
-        screen_rect.width(),
-        screen_rect.height(),
+        screen_rect.x,
+        screen_rect.y,
+        screen_rect.width,
+        screen_rect.height,
         0,
-        xcb::WINDOW_CLASS_INPUT_OUTPUT as u16,
-        screen.root_visual(),
-        &values,
-    );
+        xproto::WindowClass::InputOutput,
+        screen.root_visual,
+        &value_list,
+    ).unwrap().check().unwrap();
 
     set_title(&conn, window, "hacksaw");
 
-    set_shape(&conn, window, &[xcb::Rectangle::new(0, 0, 0, 0)]);
+    set_shape(&conn, window, &[xproto::Rectangle {
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0
+    }]);
 
-    xcb::map_window(&conn, window);
+    xproto::map_window(&conn, window).unwrap().check().unwrap();
 
     if !opt.no_guides {
-        let pointer = xcb::query_pointer(&conn, root).get_reply().unwrap();
+        let pointer = xproto::query_pointer(&conn, root).unwrap().reply().unwrap();
         set_shape(
             &conn,
             window,
             &build_guides(
                 screen_rect,
-                xcb::Point::new(pointer.root_x(), pointer.root_y()),
+                xproto::Point {
+                    x: pointer.root_x,
+                    y: pointer.root_y,
+                },
                 guide_width,
             ),
         );
     }
 
-    conn.flush();
+    conn.flush().unwrap();
 
-    let mut start_pt = xcb::Point::new(0, 0);
-    let mut selection = xcb::Rectangle::new(0, 0, 0, 0);
+    let mut start_pt = xproto::Point {
+        x: 0,
+        y: 0
+    };
+    let mut selection = xproto::Rectangle {
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0
+    };
 
     let mut in_selection = false;
     let mut ignore_next_release = false;
@@ -118,84 +142,101 @@ fn main() -> Result<(), String> {
     loop {
         let ev = conn
             .wait_for_event()
-            .ok_or_else(|| "Error getting X event, quitting.".to_string())?;
+            .map_err(|_| "Error getting X event, quitting.".to_string())?;
 
-        match ev.response_type() {
-            xcb::BUTTON_PRESS => {
-                let button_press: &xcb::ButtonPressEvent = unsafe { xcb::cast_event(&ev) };
-
-                let detail = button_press.detail();
+        match ev {
+            Event::ButtonPress(button_press) => {
+                let detail = button_press.detail;
                 if detail == 3 {
                     return Err("Exiting due to right click".into());
                 } else {
                     set_shape(&conn, window, &[]);
-                    conn.flush();
-                    start_pt = xcb::Point::new(button_press.event_x(), button_press.event_y());
+                    conn.flush().unwrap();
+                    start_pt = xproto::Point {
+                        x: button_press.event_x,
+                        y: button_press.event_y
+                    };
 
                     in_selection = !(detail == 4 || detail == 5);
                     ignore_next_release = detail == 4 || detail == 5;
                 }
             }
-            xcb::KEY_PRESS => {
+            Event::KeyPress(_) => {
                 // This will only happen with an escape key since we only grabbed escape
                 return Err("Exiting due to ESC key press".into());
             }
-            xcb::MOTION_NOTIFY => {
-                let motion: &xcb::MotionNotifyEvent = unsafe { xcb::cast_event(&ev) };
-
-                let (left_x, right_x) = min_max(motion.event_x(), start_pt.x());
-                let (top_y, bottom_y) = min_max(motion.event_y(), start_pt.y());
+            Event::MotionNotify(motion) => {
+                let (left_x, right_x) = min_max(motion.event_x, start_pt.x);
+                let (top_y, bottom_y) = min_max(motion.event_y, start_pt.y);
                 let width = (right_x - left_x) as u16;
                 let height = (bottom_y - top_y) as u16;
 
                 // only save the width and height if we are selecting a
                 // rectangle, since we then use these (non-zero width/height)
                 // to determine if a selection was made.
-                if in_selection {
-                    selection = xcb::Rectangle::new(left_x, top_y, width, height);
+                selection = if in_selection {
+                    xproto::Rectangle {
+                        x: left_x,
+                        y: top_y,
+                        width,
+                        height,
+                    }
                 } else {
-                    selection = xcb::Rectangle::new(left_x, top_y, 0, 0);
-                }
+                    xproto::Rectangle {
+                        x: left_x,
+                        y: top_y,
+                        width: 0,
+                        height: 0,
+                    }
+                };
 
                 if in_selection {
                     let rects = [
                         // Selection rectangle
-                        xcb::Rectangle::new(
-                            left_x - line_width as i16,
-                            top_y,
-                            line_width,
-                            height + line_width,
-                        ),
-                        xcb::Rectangle::new(
-                            left_x - line_width as i16,
-                            top_y - line_width as i16,
-                            width + line_width,
-                            line_width,
-                        ),
-                        xcb::Rectangle::new(
-                            right_x,
-                            top_y - line_width as i16,
-                            line_width,
-                            height + line_width,
-                        ),
-                        xcb::Rectangle::new(left_x, bottom_y, width + line_width, line_width),
+                        xproto::Rectangle {
+                            x: left_x - line_width as i16,
+                            y: top_y,
+                            width: line_width,
+                            height: height + line_width,
+                        },
+                        xproto::Rectangle {
+                            x: left_x - line_width as i16,
+                            y: top_y - line_width as i16,
+                            width: width + line_width,
+                            height: line_width,
+                        },
+                        xproto::Rectangle {
+                            x: right_x,
+                            y: top_y - line_width as i16,
+                            width: line_width,
+                            height: height + line_width,
+                        },
+                        xproto::Rectangle {
+                            x: left_x,
+                            y: bottom_y,
+                            width: width + line_width,
+                            height: line_width
+                        },
                     ];
+
                     set_shape(&conn, window, &rects);
                 } else if !opt.no_guides {
                     let rects = build_guides(
                         screen_rect,
-                        xcb::Point::new(motion.event_x(), motion.event_y()),
+                        xproto::Point {
+                            x: motion.event_x,
+                            y: motion.event_y,
+                        },
                         guide_width,
                     );
 
                     set_shape(&conn, window, &rects);
                 }
 
-                conn.flush();
+                conn.flush().unwrap();
             }
-            xcb::BUTTON_RELEASE => {
-                let motion: &xcb::ButtonReleaseEvent = unsafe { xcb::cast_event(&ev) };
-                let detail = motion.detail();
+            Event::ButtonRelease(button_release) => {
+                let detail = button_release.detail;
                 if detail == 4 || detail == 5 {
                     continue; // Scroll wheel up/down release
                 } else if ignore_next_release {
@@ -210,22 +251,20 @@ fn main() -> Result<(), String> {
         };
     }
 
-    xcb::ungrab_pointer(&conn, xcb::CURRENT_TIME);
+    xproto::ungrab_pointer(&conn, x11rb::CURRENT_TIME).unwrap().check().unwrap();
     ungrab_key(&conn, root, escape_keycode);
-    xcb::unmap_window(&conn, window);
-    xcb::destroy_window(&conn, window);
-    conn.flush();
+    xproto::unmap_window(&conn, window).unwrap().check().unwrap();
+    xproto::destroy_window(&conn, window).unwrap().check().unwrap();
+    conn.flush().unwrap();
 
     loop {
         let ev = conn
             .wait_for_event()
-            .ok_or_else(|| "Error getting X event, quitting.".to_string())?;
+            .map_err(|_| "Error getting X event, quitting.".to_string())?;
 
-        match ev.response_type() {
-            xcb::UNMAP_NOTIFY => {
-                break;
-            }
-            xcb::DESTROY_NOTIFY => {
+        match ev {
+            x11rb::protocol::Event::UnmapNotify(_)
+            | x11rb::protocol::Event::DestroyNotify(_) => {
                 break;
             }
             _ => (),
@@ -234,11 +273,11 @@ fn main() -> Result<(), String> {
     std::thread::sleep(std::time::Duration::from_millis(40));
 
     let result;
-    if selection.width() == 0 && selection.height() == 0 {
+    if selection.width == 0 && selection.height == 0 {
         // Grab window under cursor
         result = match get_window_at_point(&conn, root, start_pt, opt.remove_decorations) {
             Some(r) => r,
-            None => get_window_geom(&conn, screen.root()),
+            None => get_window_geom(&conn, screen.root),
         }
     } else {
         result = HacksawResult {


### PR DESCRIPTION
I managed to typo in the commit. nice. Anyway this switches our xcb library to x11rb because it's very nice.

I tried to leave as much of the code as similar to the original as possible to make the diff easier to review.