### PR TITLE
Make the binary build on FreeBSD

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,7 @@
+#[cfg(not(target_os = "freebsd"))]
+fn main() {}
+
+#[cfg(target_os = "freebsd")]
+fn main() {
+    println!("cargo:rustc-link-search=/usr/local/lib");
+}


### PR DESCRIPTION
FreeBSD does not have the needed libraries
in the default search path.

This patch adds the needed folder to the
search path of `rustc` on FreeBSD.