### PR TITLE
Grab all escape key codes

### DIFF
--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -139,41 +139,52 @@ pub fn grab_pointer_set_cursor(conn: &xcb::Connection, root: u32) -> bool {
     false
 }
 
-pub fn find_escape_keycode(conn: &xcb::Connection) -> xcb::Keycode {
-    // https://stackoverflow.com/questions/18689863/obtain-keyboard-layout-and-keysyms-with-xcb
+pub fn find_escape_keycodes(conn: &xcb::Connection) -> Vec<xcb::Keycode> {
     let setup = conn.get_setup();
-    let cookie = xcb::get_keyboard_mapping(
-        &conn,
-        setup.min_keycode(),
-        setup.max_keycode() - setup.min_keycode() + 1,
-    );
-    let reply = cookie.get_reply().expect("failed to get keyboard mapping");
+    let min = setup.min_keycode();
+    let max = setup.max_keycode();
+    let count = max - min + 1;
 
-    let escape_index = reply
+    let reply = xcb::get_keyboard_mapping(conn, min, count)
+        .get_reply()
+        .expect("failed to get keyboard mapping");
+    let syms_per_code = reply.keysyms_per_keycode() as usize;
+
+    reply
         .keysyms()
-        .iter()
-        .position(|&keysym| keysym == ESC_KEYSYM)
-        .expect("failed to find escape keysym");
-    (escape_index / reply.keysyms_per_keycode() as usize) as u8 + setup.min_keycode()
+        .chunks(syms_per_code)
+        .enumerate()
+        .filter_map(|(i, chunk)| {
+            if chunk.iter().any(|&keysym| keysym == ESC_KEYSYM) {
+                Some(min + i as u8)
+            } else {
+                None
+            }
+        })
+        .collect()
 }
 
-pub fn grab_key(conn: &xcb::Connection, root: u32, keycode: u8) {
-    for mask in 0..=KEY_GRAB_MASK_MAX {
-        xcb::grab_key(
-            &conn,
-            true,
-            root,
-            mask as u16,
-            keycode,
-            xcb::GRAB_MODE_ASYNC as u8,
-            xcb::GRAB_MODE_ASYNC as u8,
-        );
+pub fn grab_keys(conn: &xcb::Connection, root: u32, keycodes: &[xcb::Keycode]) {
+    for &keycode in keycodes {
+        for mask in 0..=KEY_GRAB_MASK_MAX {
+            xcb::grab_key(
+                conn,
+                true,
+                root,
+                mask as u16,
+                keycode,
+                xcb::GRAB_MODE_ASYNC as u8,
+                xcb::GRAB_MODE_ASYNC as u8,
+            );
+        }
     }
 }
 
-pub fn ungrab_key(conn: &xcb::Connection, root: u32, keycode: u8) {
-    for mask in 0..=KEY_GRAB_MASK_MAX {
-        xcb::ungrab_key(&conn, keycode, root, mask as u16);
+pub fn ungrab_keys(conn: &xcb::Connection, root: u32, keycodes: &[xcb::Keycode]) {
+    for &keycode in keycodes {
+        for mask in 0..=KEY_GRAB_MASK_MAX {
+            xcb::ungrab_key(conn, keycode, root, mask as u16);
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,8 @@ mod lib;
 
 use lib::parse_args::Opt;
 use lib::{
-    find_escape_keycode, get_window_at_point, get_window_geom, grab_key, grab_pointer_set_cursor,
-    set_shape, set_title, ungrab_key, HacksawResult, CURSOR_GRAB_TRIES,
+    find_escape_keycodes, get_window_at_point, get_window_geom, grab_keys, grab_pointer_set_cursor,
+    set_shape, set_title, ungrab_keys, HacksawResult, CURSOR_GRAB_TRIES,
 };
 use structopt::StructOpt;
 
@@ -52,8 +52,8 @@ fn main() -> Result<(), String> {
         ));
     }
 
-    let escape_keycode = find_escape_keycode(&conn);
-    grab_key(&conn, root, escape_keycode);
+    let escape_keycodes = find_escape_keycodes(&conn);
+    grab_keys(&conn, root, &escape_keycodes);
 
     let screen_rect =
         xcb::Rectangle::new(0, 0, screen.width_in_pixels(), screen.height_in_pixels());
@@ -211,7 +211,7 @@ fn main() -> Result<(), String> {
     }
 
     xcb::ungrab_pointer(&conn, xcb::CURRENT_TIME);
-    ungrab_key(&conn, root, escape_keycode);
+    ungrab_keys(&conn, root, &escape_keycodes);
     xcb::unmap_window(&conn, window);
     xcb::destroy_window(&conn, window);
     conn.flush();


### PR DESCRIPTION
This finds all keys that are mapped to escape and grabs them for
aborting the use of hacksaw.

I admit to not having coded rust before and having solved this with an LLM but
the change fixed the desired behavior for me since I have mapped caps lock to
be an extra escape.
